### PR TITLE
Fix hasBlock deprecation

### DIFF
--- a/addon/templates/components/place-autocomplete-field.hbs
+++ b/addon/templates/components/place-autocomplete-field.hbs
@@ -1,4 +1,4 @@
-{{#if hasBlock}}
+{{#if (has-block)}}
   {{yield this}}
 {{else}}
   <input


### PR DESCRIPTION
`hasBlock` is deprecated in favor of `has-block` and will break in Ember 4. Building an app that uses `ember-place-autocomplete` results in the following warning on recent Ember versions:

> DEPRECATION: `hasBlock` is deprecated. Use `has-block` instead. ('ember-place-autocomplete/templates/components/place-autocomplete-field.hbs' @ L1:C6)

See the following references:

- https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params
- https://github.com/emberjs/rfcs/blob/master/text/0689-deprecate-has-block.md